### PR TITLE
Use local variable for this.filetype

### DIFF
--- a/lib/tilelive-file.js
+++ b/lib/tilelive-file.js
@@ -73,16 +73,18 @@ File.prototype.putInfo = function(info, callback) {
 
 File.prototype.putTile = function(z, x, y, tile, callback) {
     var dir = path.join(this.basepath, String(z), String(x));
+    var type = this.filetype;
     mkdirp(dir, function(err) {
         if (err) return callback(err);
-        fs.writeFile(path.join(dir, y + '.' + this.filetype), tile, callback);
+        fs.writeFile(path.join(dir, y + '.' + type), tile, callback);
     });
 };
 
 File.prototype.putGrid = function(z, x, y, grid, callback) {
     var data = JSON.stringify(grid);
     var dir = path.join(this.basepath, String(z), String(x));
+    var type = this.filetype;
     mkdirp(dir, function(err) {
-        fs.writeFile(path.join(dir, y + '.' + this.filetype), data, callback);
+        fs.writeFile(path.join(dir, y + '.' + type), data, callback);
     });
 };


### PR DESCRIPTION
Because `this` is not guaranteed to be the same
in the callback as the one in the parent closure.
Otherwise this.filetype is undefined.
